### PR TITLE
Fix error where form validation messages not appearing when expected.

### DIFF
--- a/src/app/donation-form/donation-form.component.html
+++ b/src/app/donation-form/donation-form.component.html
@@ -12,40 +12,40 @@
   <form (ngSubmit)="onSubmit()" #donationForm="ngForm">
       <div class="form-group">
           <label for="firstName">First Name</label>
-          <input type="text" class="form-control" id="firstName" placeholder="Enter first name" required [(ngModel)]="model.firstName" name="firstName" #name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="firstName" placeholder="Enter first name" required [(ngModel)]="model.firstName" name="firstName" #firstName="ngModel">
+          <div [hidden]="firstName.valid || firstName.pristine"
           class="alert alert-danger">
           Please enter your first name
           </div>
       </div>
       <div class="form-group">
           <label for="lastName">Last Name</label>
-          <input type="text" class="form-control" id="lastName" placeholder="Enter last name" required [(ngModel)]="model.lastName" name="lastName" #name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="lastName" placeholder="Enter last name" required [(ngModel)]="model.lastName" name="lastName" #lastName="ngModel">
+          <div [hidden]="lastName.valid || lastName.pristine"
           class="alert alert-danger">
           Please enter your last name
           </div>
       </div>
       <div class="form-group">
           <label for="email">Email address</label>
-          <input type="text" class="form-control" id="email" placeholder="Enter email" required [(ngModel)]="model.email" name="email" #name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="email" placeholder="Enter email" required [(ngModel)]="model.email" name="email" #email="ngModel">
+          <div [hidden]="email.valid || email.pristine"
           class="alert alert-danger">
           Please enter your email
           </div>
       </div>
       <div class="form-group">
           <label for="phoneNumber">Phone Number</label>
-          <input type="text" class="form-control" id="phoneNumber" placeholder="Enter phone number" required [(ngModel)]="model.phoneNumber" name="phoneNumber"#name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="phoneNumber" placeholder="Enter phone number" required [(ngModel)]="model.phoneNumber" name="phoneNumber"#phoneNumber="ngModel">
+          <div [hidden]="phoneNumber.valid || phoneNumber.pristine"
           class="alert alert-danger">
           Please enter your phone number
           </div>
       </div>
       <div class="form-group">
           <label for="description"><h6>What item(s) are you donating?</h6></label>
-          <textarea class="form-control" id="description" input type="text" rows="10" required [(ngModel)]="model.description" name="description" #name="ngModel"></textarea>
-          <div [hidden]="name.valid || name.pristine"
+          <textarea class="form-control" id="description" input type="text" rows="10" required [(ngModel)]="model.description" name="description" #description="ngModel"></textarea>
+          <div [hidden]="description.valid || description.pristine"
           class="alert alert-danger">
           Please list item(s) you wish to donate
           </div>

--- a/src/app/request-form/request-form.component.html
+++ b/src/app/request-form/request-form.component.html
@@ -12,40 +12,40 @@
   <form (ngSubmit)="onSubmit()" #requestForm="ngForm">
       <div class="form-group">
           <label for="firstName">First Name</label>
-          <input type="text" class="form-control" id="firstName" placeholder="Enter first name" required [(ngModel)]="model.firstName" name="firstName" #name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="firstName" placeholder="Enter first name" required [(ngModel)]="model.firstName" name="firstName" #firstName="ngModel">
+          <div [hidden]="firstName.valid || firstName.pristine"
           class="alert alert-danger">
           Please enter your first name
           </div>
       </div>
       <div class="form-group">
           <label for="lastName">Last Name</label>
-          <input type="text" class="form-control" id="lastName" placeholder="Enter last name" required [(ngModel)]="model.lastName" name="lastName" #name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="lastName" placeholder="Enter last name" required [(ngModel)]="model.lastName" name="lastName" #lastName="ngModel">
+          <div [hidden]="lastName.valid || lastName.pristine"
           class="alert alert-danger">
           Please enter your last name
           </div>
       </div>
       <div class="form-group">
           <label for="email">Email address</label>
-          <input type="text" class="form-control" id="email" placeholder="Enter email" required [(ngModel)]="model.email" name="email" #name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="email" placeholder="Enter email" required [(ngModel)]="model.email" name="email" #email="ngModel">
+          <div [hidden]="email.valid || email.pristine"
           class="alert alert-danger">
           Please enter your email
           </div>
       </div>
       <div class="form-group">
           <label for="phoneNumber">Phone Number</label>
-          <input type="text" class="form-control" id="phoneNumber" placeholder="Enter phone number" required [(ngModel)]="model.phoneNumber" name="phoneNumber"#name="ngModel">
-          <div [hidden]="name.valid || name.pristine"
+          <input type="text" class="form-control" id="phoneNumber" placeholder="Enter phone number" required [(ngModel)]="model.phoneNumber" name="phoneNumber"#phoneNumber="ngModel">
+          <div [hidden]="phoneNumber.valid || phoneNumber.pristine"
           class="alert alert-danger">
           Please enter your phone number
           </div>
       </div>
       <div class="form-group">
           <label for="description"><h6>What item(s) are you requesting?</h6></label>
-          <textarea class="form-control" id="description" input type="text" rows="10" required [(ngModel)]="model.description" name="description" #name="ngModel"></textarea>
-          <div [hidden]="name.valid || name.pristine"
+          <textarea class="form-control" id="description" input type="text" rows="10" required [(ngModel)]="model.description" name="description" #description="ngModel"></textarea>
+          <div [hidden]="description.valid || description.pristine"
           class="alert alert-danger">
           Please list item(s) you wish to request
           </div>


### PR DESCRIPTION
Although form validation messages in the donation form and request form templates were set to appear when a form field had been edited and contained an invalid value (i.e. a user began to fill in and then cleared a field), these messages were not appearing when expected. Each form input tag in the form templates previously contained a declaration of a reference variable with identical name, "#name." Now, each input of each template declares a reference variable unique to that field of that template (e.g. "#phoneNumber"), and the div containing the error message uses the unique reference variable to check the state of the field. Error messages now appear as expected.

Since this error was present in both request-form.component.html and donation-form.component.html, identical changes have been made to each form template.

I based this contribution off of the guidance in the [Angular Docs Template Syntax page's "Template Reference Variables" section](https://angular.io/guide/template-syntax#ref-vars).